### PR TITLE
Tools Header

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -123,8 +123,7 @@
                         </div>
                         <div class="col-md-3 widget">
                             <div class="title">
-                                <h3 class="with-subtitle">ADELA</h3>
-                                <p class="single-line">Aceleradora de la apertura</p>
+                                <h3>ADELA</h3>
                             </div>
                             <div class="body">
                                 <img src="img/ic_adela.png" />
@@ -142,8 +141,7 @@
                         </div>
                         <div class="col-md-3 widget">
                             <div class="title">
-                                <h3 class="with-subtitle">IRIS</h3>
-                                <p>Índice de Preparación de Información Subnacional</p>
+                                <h3>IRIS</h3>
                             </div>
                             <div class="body">
                                 <img src="img/ic_iris.png" />

--- a/app/less/style.less
+++ b/app/less/style.less
@@ -73,10 +73,7 @@ form .form-control                                  { border: 1px solid #979797;
 ********************************/
 #tools                                              { margin-bottom: 50px; }
 #tools .widget .title                               { margin-bottom: 20px; border-bottom: 1px solid #4d4d4d; text-align: center; }
-#tools .widget .title > h3                          { padding-bottom: 51px; }
-#tools .widget .title > h3.with-subtitle            { padding-bottom: 0; }
-#tools .widget .title > p                           { margin-bottom: 5px; font-size: 16px; font-weight: 300; color: #4d4d4d; }
-#tools .widget .title > p.single-line               { margin-bottom: 28px; }
+#tools .widget .title > h3                          { padding-bottom: 11px; }
 #tools .widget .body                                { text-align: center; }
 #tools .widget .body img                            { margin-bottom: 20px; }
 


### PR DESCRIPTION
Modified site tools section header, removed tools subtitles

Closes #135 

<img width="1054" alt="screen shot 2016-04-20 at 19 40 41" src="https://cloud.githubusercontent.com/assets/1383865/14694637/f073df66-072f-11e6-834d-898e88a35ec6.png">