### PR TITLE
Build Fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,7 @@ module.exports  = function ( grunt ) {
                         'partials/{,*/}*.html',
                         'img/{,*/}*.*',
                         'css/{,*/}*.css',
+                        'js/{,*/}*.js',
                         'data/{,*/}*.*',
                         'CNAME'
                     ]
@@ -70,41 +71,6 @@ module.exports  = function ( grunt ) {
                     cwd     : '.',
                     src     : 'bower_components/bootstrap/fonts/*',
                     dest    : '<%= config.dist %>/fonts'
-                }, {
-                    expand  : true,
-                    cwd     : '.',
-                    src     : 'bower_components/requirejs/require.js',
-                    dest    : '<%= config.dist %>'
-                }, {
-                    expand  : true,
-                    cwd     : '.',
-                    src     : [
-                        'bower_components/polymer/polymer.html',
-                        'bower_components/polymer/polymer-mini.html',
-                        'bower_components/polymer/polymer-micro.html'
-                    ],
-                    dest    : '<%= config.dist %>'
-                }, {
-                    expand  : true,
-                    cwd     : '.',
-                    src     : 'bower_components/dgm-navbar/dgm-navbar.html',
-                    dest    : '<%= config.dist %>'
-                }, {
-                    expand  : true,
-                    cwd     : '.',
-                    src     : 'bower_components/dgm-footer/dgm-footer.html',
-                    dest    : '<%= config.dist %>'
-                }]
-            },
-            altdist : {
-                files   : [{
-                    expand  : true,
-                    dot     : true,
-                    cwd     : '<%= config.app %>',
-                    dest    : '<%= config.dist %>',
-                    src     : [
-                        'img/ic-*.png'
-                    ]
                 }]
             }
         },
@@ -137,6 +103,7 @@ module.exports  = function ( grunt ) {
         filerev                 : {
             dist    : {
                 src : [
+                    '<%= config.dist %>/js/site.js',
                     '<%= config.dist %>/js/vendor.js',
                     '<%= config.dist %>/css/{,*/}*.css',
                     '<%= config.dist %>/img/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
@@ -238,7 +205,7 @@ module.exports  = function ( grunt ) {
                     html: {
                         steps   : {
                             js  : ['concat', 'uglify'],
-                            css : ['cssmin']
+                            css : ['concat', 'cssmin']
                         },
                         post: {}
                     }
@@ -291,11 +258,11 @@ module.exports  = function ( grunt ) {
         'concat',
         'copy:dist',
         'cdnify',
+        'cssmin',
         'uglify',
         'filerev',
         'usemin',
-        'htmlmin',
-        'copy:altdist'
+        'htmlmin'
     ]);
     grunt.registerTask( 'publish', [
         'build',

--- a/app/index.html
+++ b/app/index.html
@@ -12,9 +12,7 @@
         <link rel="stylesheet" href="bower_components/leaflet/dist/leaflet.css" />
         <!-- endbower -->
         <!-- endbuild -->
-        <!-- build:css(.tmp) css/style.css -->
         <link rel="stylesheet" href="css/style.css">
-        <!-- endbuild -->
     </head>
     <body>
         <nav class="navbar navbar-default">
@@ -322,8 +320,8 @@
         <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
         <script src="bower_components/leaflet/dist/leaflet-src.js"></script>
         <!-- endbower -->
+        <!-- endbuild -->
         <script src="http://d3js.org/topojson.v1.min.js"></script>
         <script src="js/site.js"></script>
-        <!-- endbuild -->
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "grunt-contrib-concat"          : "^0.5.1",
         "grunt-contrib-connect"         : "^0.10.1",
         "grunt-contrib-copy"            : "^0.8.0",
+        "grunt-contrib-cssmin"          : "^1.0.0",
         "grunt-contrib-htmlmin"         : "^0.4.0",
         "grunt-contrib-imagemin"        : "^1.0.0",
         "grunt-contrib-less"            : "^1.0.0",


### PR DESCRIPTION
Fixed bug that prevented the application bower components css from being added to the generated site

<img width="1188" alt="screen shot 2016-04-27 at 21 55 00" src="https://cloud.githubusercontent.com/assets/1383865/14874117/b891b490-0cc2-11e6-8334-f3e9d6255940.png">

## Testing

- [ ] Install the application dependencies with `npm install` and  `bower install`
- [ ] Build the application by running `grunt build`
- [ ] Open the `index.html` file under `dist` directory
- [ ] Check that the map is displayed correctly (the states polygons won't load since the site is not being loaded from a server)